### PR TITLE
Added additional test

### DIFF
--- a/src/apiHelpers.test.js
+++ b/src/apiHelpers.test.js
@@ -14,28 +14,28 @@ test('returns data from captains endpoint', async () => {
   expect(captains[0]).toEqual(firstCaptain);
 });
 
-xtest('captain first names', async () => {
+test('captain first names', async () => {
   const expectedNames = ['Jack', 'Malcolm', 'Jean Luc', 'Han'];
   const firstNames = await apiHelpers.firstNames();
 
   expect(firstNames).toEqual(expectedNames);
 });
 
-xtest('captain first names sorted alphabetically', async () => {
+test('captain first names sorted alphabetically', async () => {
   const expectedNames = ['Han', 'Jack', 'Jean Luc', 'Malcolm'];
   const firstNamesSorted = await apiHelpers.firstNamesSorted();
 
   expect(firstNamesSorted).toEqual(expectedNames);
 });
 
-xtest('captain combined total age', async () => {
+test('captain combined total age', async () => {
   const expectedTotalAge = 179;
   const totalAge = await apiHelpers.totalAge();
 
   expect(totalAge).toEqual(expectedTotalAge);
 });
 
-xtest('captain full names sorted by age ascending', async () => {
+test('captain full names sorted by age ascending', async () => {
   const expectedNames = [
     'Han Solo',
     'Malcolm Reynolds',
@@ -47,7 +47,7 @@ xtest('captain full names sorted by age ascending', async () => {
   expect(fullNamesByAge).toEqual(expectedNames);
 });
 
-xtest('captain and ship combined for given captain id', async () => {
+test('captain and ship combined for given captain id', async () => {
   const expectedData = {
     id: 'R6TZN',
     firstName: 'Malcolm',
@@ -58,4 +58,40 @@ xtest('captain and ship combined for given captain id', async () => {
   const captainShipData = await apiHelpers.captainBio('R6TZN');
 
   expect(captainShipData).toEqual(expectedData);
+});
+
+xtest('Captains sorted by ship size', async () => {
+  const expectedData = [
+    {
+      id: "KZUC8",
+      first: "Han",
+      last: "Solo",
+      age: 33,
+      ship: "Millenium Falcon"
+    },
+    {
+      id: "R6TZN",
+      first: "Malcolm",
+      last: "Reynolds",
+      age: 34,
+      ship: "Serenity"
+    },
+    {
+      id: "SQ2WI",
+      first: "Jack",
+      last: "Sparrow",
+      age: 48,
+      ship: "Black Pearl"
+    },
+    {
+      id: "UXWPK",
+      first: "Jean Luc",
+      last: "Picard",
+      age: 64,
+      ship: "USS Enterprise NCC-1701-D"
+    }
+  ]
+  const captainsWithShipNamesBySize = await apiHelpers.captainsWithShipNamesBySize()
+
+  expect(captainsWithShipNamesBySize).toEqual(expectedData);
 });


### PR DESCRIPTION
This new test asks for the captain data, but with ship being the name of the ship instead of the ID. It's also sorted by size of the crew of the ship. This test is to give them a slightly more complex interaction between the captain and ship data sets so the answer will be less straightforward. The Denver interviewers talked about possibly adding a new question because we found that the JS pairing exercise was a lot simpler than the exercises for other language. We thought at the very least having one more test added onto the end won't hurt anything if the interviewer doesn't want to have the candidate attempt it.