### PR TITLE
Fix silent test failures and add api:stop script

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,6 +2,6 @@
   "eslint.autoFixOnSave": true,
   "editor.formatOnSave": true,
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true
+    "source.fixAll.eslint": "explicit"
   }
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "scripts": {
     "test": "jest --watch --verbose",
-    "api": "json-server --port 4000 ./api/db.json"
+    "api": "json-server --port 4000 ./api/db.json",
+    "api:stop": "pkill -f 'json-server' || true"
   },
   "jest": {
     "testEnvironment": "node",

--- a/src/apiClient.test.js
+++ b/src/apiClient.test.js
@@ -5,23 +5,25 @@ test('apiClient is configured to point to api', () => {
 });
 
 test('api/captains endpoint works', async () => {
+  expect.assertions(2);
   try {
     const response = await apiClient.get('/captains');
     expect(response.status).toBe(200);
     expect(response.data).toHaveLength(4);
   } catch (error) {
     console.log('Be sure you have started the mock api: npm run api');
-    expect(true).toBe(false);
+    throw error;
   }
 });
 
 test('api/ships endpoint works', async () => {
+  expect.assertions(2);
   try {
     const response = await apiClient.get('/ships');
     expect(response.status).toBe(200);
     expect(response.data).toHaveLength(4);
   } catch (error) {
     console.log('Be sure you have started the mock api: npm run api');
-    expect(true).toBe(false);
+    throw error;
   }
 });


### PR DESCRIPTION
## Summary

- Replace `expect(true).toBe(false)` antipattern in integration tests with `expect.assertions(2)` + `throw error` so failures are loud and explicit
- Add `npm run api:stop` script (`pkill -f 'json-server' || true`) for convenience
- Update deprecated VS Code `source.fixAll.eslint: true` to `"explicit"` (new string enum format)

## Test plan

- [ ] `npm run api` then `npm test` — integration tests pass
- [ ] Stop the API, run tests again — integration tests fail with a real error (not a silent pass)
- [ ] `npm run api:stop` kills the json-server process

🤖 Generated with [Claude Code](https://claude.com/claude-code)